### PR TITLE
A lot of `const` into `commons` obj

### DIFF
--- a/background.js
+++ b/background.js
@@ -20,7 +20,7 @@ var supportCopyImage = false;
 class ExecutorClass {
     constructor() {
         this.data = {
-            direction: DIR_U,
+            direction: commons.DIR_U,
             selection: "",
             sendToOptions: false,
             actionType: "textAction"
@@ -39,36 +39,36 @@ class ExecutorClass {
             return;
         }
         switch (this.action.act_name) {
-            case ACT_OPEN:
+            case commons.ACT_OPEN:
                 this.openURL(this.data.selection);
                 break;
-            case ACT_COPY:
+            case commons.ACT_COPY:
                 this.copy();
                 break;
-            case ACT_SEARCH:
-                if (this.action.search_type === SEARCH_LINK) this.searchText(this.data.selection);
+            case commons.ACT_SEARCH:
+                if (this.action.search_type === commons.SEARCH_LINK) this.searchText(this.data.selection);
                 else this.searchText(this.data.textSelection);
                 break;
-            case ACT_DL:
+            case commons.ACT_DL:
                 this.downloadImage(this.data.selection);
                 break;
-            case ACT_TRANS:
+            case commons.ACT_TRANS:
                 break;
         }
     }
     getTabIndex(tabsLength = 0, currentTabIndex = 0) {
         let index = 0;
         switch (this.action.tab_pos) {
-            case TAB_CLEFT:
+            case commons.TAB_CLEFT:
                 index = currentTabIndex;
                 break;
-            case TAB_CRIGHT:
+            case commons.TAB_CRIGHT:
                 index = currentTabIndex + 1;
                 break;
-            case TAB_FIRST:
+            case commons.TAB_FIRST:
                 index = 0;
                 break;
-            case TAB_LAST:
+            case commons.TAB_LAST:
                 index = tabsLength;
                 break;
             default:
@@ -81,7 +81,7 @@ class ExecutorClass {
         browser.tabs.query({}).then(tabs => {
             for (let tab of tabs) {
                 if (tab.active === true) {
-                    if (this.action.tab_pos == TAB_CUR) browser.tabs.update(tab.id, { url: url });
+                    if (this.action.tab_pos == commons.TAB_CUR) browser.tabs.update(tab.id, { url: url });
                     else {
                         browser.tabs.create({
                             active: this.action.tab_active,
@@ -260,7 +260,7 @@ browser.browserAction.onClicked.addListener(() => {
     browser.runtime.openOptionsPage();
 });
 
-browser.runtime.sendNativeMessage(appName, "test").then(
+browser.runtime.sendNativeMessage(commons.appName, "test").then(
     response => {
         console.log("From native app:" + response);
         supportCopyImage = true;
@@ -269,7 +269,7 @@ browser.runtime.sendNativeMessage(appName, "test").then(
 );
 
 function sendImageToNative(base64) {
-    let sending = browser.runtime.sendNativeMessage(appName, base64);
+    let sending = browser.runtime.sendNativeMessage(commons.appName, base64);
     sending.then((response) => {
         console.log("Receive:" + response);
     }, (error) => {

--- a/common.js
+++ b/common.js
@@ -1,54 +1,57 @@
-const urlPattern = /^(https?:\/\/)?((\w|-)*\.){0,3}((\w|-)+)\.(com|net|org|gov|edu|mil|biz|cc|info|fm|mobi|tv|ag|am|asia|at|au|be|br|bz|ca|cn|co|de|do|ee|es|eu|fr|gd|gl|gs|im|in|it|jp|la|ly|me|mp|ms|mx|nl|pe|ph|ru|se|so|tk|to|tt|tw|us|uk|ws|xxx)(\/(\w|%|&|-|_|\||\?|\.|=|\/|#|~|!|\+|,|\*|@)*)?$/i
-//from superdrag   https://addons.mozilla.org/en-US/firefox/addon/super-drag/
-const appName = "setClipboard";
+/* exported commons */
 
-const TYPE_UNKNOWN = -1; //未知类型
-const TYPE_TEXT = 0; //文本,包含普通文本、链接
-const TYPE_TEXT_URL = 1; //链接
-const TYPE_TEXT_AREA = 5
-const TYPE_ELEM = 2; //元素，主要是没有选中文本，对元素进行了拖拽
-const TYPE_ELEM_A = 3; //超链接，a元素
-const TYPE_ELEM_IMG = 4;
+const commons = {
+    urlPattern: /^(https?:\/\/)?((\w|-)*\.){0,3}((\w|-)+)\.(com|net|org|gov|edu|mil|biz|cc|info|fm|mobi|tv|ag|am|asia|at|au|be|br|bz|ca|cn|co|de|do|ee|es|eu|fr|gd|gl|gs|im|in|it|jp|la|ly|me|mp|ms|mx|nl|pe|ph|ru|se|so|tk|to|tt|tw|us|uk|ws|xxx)(\/(\w|%|&|-|_|\||\?|\.|=|\/|#|~|!|\+|,|\*|@)*)?$/i,
+    //from superdrag   https://addons.mozilla.org/en-US/firefox/addon/super-drag/
+    appName: "setClipboard",
 
-const DIR_U = "DIR_U";
-const DIR_D = "DIR_D";
-const DIR_L = "DIR_L";
-const DIR_R = "DIR_R";
+    TYPE_UNKNOWN: -1, //未知类型
+    TYPE_TEXT: 0, //文本,包含普通文本、链接
+    TYPE_TEXT_URL: 1, //链接
+    TYPE_TEXT_AREA: 5,
+    TYPE_ELEM: 2, //元素，主要是没有选中文本，对元素进行了拖拽
+    TYPE_ELEM_A: 3, //超链接，a元素
+    TYPE_ELEM_IMG: 4,
 
-const ACT_NONE = "ACT_NONE"; //无动作
-const ACT_OPEN = "ACT_OPEN"; //打开
-const ACT_COPY = "ACT_COPY" //复制
-const ACT_SEARCH = "ACT_SEARCH" //搜索
-const ACT_TRANS = "ACT_TRANS" //翻译
-const ACT_DL = "ACT_DL" //下载
-const ACT_QRCODE = "ACT_QRCODE" //二维码
-const COPY_LINK = "COPY_LINK"
-const COPY_TEXT = "COPY_TEXT"
-const COPY_IMAGE = "COPY_IMAGE"
-const SEARCH_TEXT = "SEARCH_TEXT"
-const SEARCH_LINK = "SEARCH_LINK"
-const SEARCH_IMAGE = "SEARCH_IMAGE"
+    DIR_U: "DIR_U",
+    DIR_D: "DIR_D",
+    DIR_L: "DIR_L",
+    DIR_R: "DIR_R",
 
-// const KEY_CTRL = 0;//ctrl键
-// const KEY_SHIFT = 1;//shift键
+    ACT_NONE: "ACT_NONE", //无动作
+    ACT_OPEN: "ACT_OPEN", //打开
+    ACT_COPY: "ACT_COPY", //复制
+    ACT_SEARCH: "ACT_SEARCH", //搜索
+    ACT_TRANS: "ACT_TRANS", //翻译
+    ACT_DL: "ACT_DL", //下载
+    ACT_QRCODE: "ACT_QRCODE", //二维码
+    COPY_LINK: "COPY_LINK",
+    COPY_TEXT: "COPY_TEXT",
+    COPY_IMAGE: "COPY_IMAGE",
+    SEARCH_TEXT: "SEARCH_TEXT",
+    SEARCH_LINK: "SEARCH_LINK",
+    SEARCH_IMAGE: "SEARCH_IMAGE",
 
-const NEW_WINDOW = "NEW_WINDOW"; //新窗口打开?
-const TAB_CUR = "TAB_CUR"; //当前标签页
-const TAB_FIRST = "TAB_FIRST"; //新建标签页在最左边
-const TAB_LAST = "TAB_LAST"; //最右边
-const TAB_CLEFT = "TAB_CLEFT"; //新建的标签页在当前标签页的左边
-const TAB_CRIGHT = "TAB_CRIGHT"; //右边
+    // KEY_CTRL: 0,//ctrl键
+    // KEY_SHIFT: 1,//shift键
 
-const FORE_GROUND = true; //前台打开
-const BACK_GROUND = false; //后台打开
+    NEW_WINDOW: "NEW_WINDOW", //新窗口打开?
+    TAB_CUR: "TAB_CUR", //当前标签页
+    TAB_FIRST: "TAB_FIRST", //新建标签页在最左边
+    TAB_LAST: "TAB_LAST", //最右边
+    TAB_CLEFT: "TAB_CLEFT", //新建的标签页在当前标签页的左边
+    TAB_CRIGHT: "TAB_CRIGHT", //右边
 
-const ALLOW_H = "ALLOW_H";
-const ALLOW_V = "ALLOW_V";
-const ALLOW_ALL = "ALLOW_ALL";
-const ALLOW_ONE = "ALLOW_ONE";
+    FORE_GROUND: true, //前台打开
+    BACK_GROUND: false, //后台打开
 
-const _DEBUG = true;
+    ALLOW_H: "ALLOW_H",
+    ALLOW_V: "ALLOW_V",
+    ALLOW_ALL: "ALLOW_ALL",
+    ALLOW_ONE: "ALLOW_ONE",
 
+    _DEBUG: true
+};
 
 function $E(s = "") {
     let r = document.querySelector(s);
@@ -59,18 +62,18 @@ function $E(s = "") {
 }
 
 function getActionType(t) {
-    if (t === TYPE_UNKNOWN) {
+    if (t === commons.TYPE_UNKNOWN) {
         console.error("未知的拖拽目标类型！~");
         return;
     }
-    if (t === TYPE_TEXT_URL || t == TYPE_ELEM_A) return "linkAction";
-    else if (t === TYPE_TEXT || t === TYPE_ELEM || t === TYPE_TEXT_AREA) return "textAction";
-    else if (t === TYPE_ELEM_IMG) return "imageAction";
+    if (t === commons.TYPE_TEXT_URL || t == commons.TYPE_ELEM_A) return "linkAction";
+    else if (t === commons.TYPE_TEXT || t === commons.TYPE_ELEM || t === commons.TYPE_TEXT_AREA) return "textAction";
+    else if (t === commons.TYPE_ELEM_IMG) return "imageAction";
 }
 
 class ActClass {
     //NEW OPT
-    constructor(act = ACT_NONE, active = BACK_GROUND, pos = TAB_LAST, en = "", search_type = SEARCH_TEXT, copy_type = COPY_LINK) {
+    constructor(act = commons.ACT_NONE, active = commons.BACK_GROUND, pos = commons.TAB_LAST, en = "", search_type = commons.SEARCH_TEXT, copy_type = commons.COPY_LINK) {
         this.act_name = act;
         this.tab_active = active;
         this.tab_pos = pos;
@@ -84,7 +87,7 @@ class ActClass {
             return true;
         }
     }
-    update(opt = { act: ACT_NONE, active: BACK_GROUND, pos: TAB_LAST, en: "", search_type: SEARCH_TEXT, copy_type: COPY_LINK }) {
+    update(opt = { act: commons.ACT_NONE, active: commons.BACK_GROUND, pos: commons.TAB_LAST, en: "", search_type: commons.SEARCH_TEXT, copy_type: commons.COPY_LINK }) {
         this.act_name = opt.act;
         this.tab_active = opt.active;
         this.tab_pos = opt.pos;
@@ -96,22 +99,22 @@ class ActClass {
 
 function checkDragTargetType(selection, target) {
    if (selection && selection.length !== 0) {
-        if (urlPattern.test(selection)) {
-            return TYPE_TEXT_URL;
+        if (commons.urlPattern.test(selection)) {
+            return commons.TYPE_TEXT_URL;
         }
-        return TYPE_TEXT;
+        return commons.TYPE_TEXT;
     }
     else if (target !== null) {
         if (target instanceof HTMLAnchorElement) {
-            return TYPE_ELEM_A;
+            return commons.TYPE_ELEM_A;
         }
         else if (target instanceof HTMLImageElement) {
-            return TYPE_ELEM_IMG;
+            return commons.TYPE_ELEM_IMG;
         }
         else if (target instanceof HTMLTextAreaElement) {
-            return TYPE_TEXT_AREA;
+            return commons.TYPE_TEXT_AREA;
         }
-        return TYPE_ELEM;
+        return commons.TYPE_ELEM;
     }
-    return TYPE_UNKNOWN;
+    return commons.TYPE_UNKNOWN;
 }

--- a/content_script.js
+++ b/content_script.js
@@ -1,3 +1,5 @@
+/* exported CSlistener */
+
 let isRunInOptionsContext = browser.runtime.getBackgroundPage !== undefined ? true : false;
 //bgConfig
 const MIME_TYPE = {
@@ -41,19 +43,19 @@ class Prompt {
         this.hide();
         document.body.appendChild(this.container);
     }
-    renderDir(d = DIR_U) {
+    renderDir(d = commons.DIR_U) {
         let name = "";
         switch (d) {
-            case DIR_U:
+            case commons.DIR_U:
                 name = "GDArrow-U";
                 break;
-            case DIR_L:
+            case commons.DIR_L:
                 name = "GDArrow-L";
                 break;
-            case DIR_R:
+            case commons.DIR_R:
                 name = "GDArrow-R";
                 break;
-            case DIR_D:
+            case commons.DIR_D:
                 name = "GDArrow-D";
                 break;
         }
@@ -112,9 +114,9 @@ class DragClass {
         );
         this.selection = "";
         this.targetElem = null;
-        this.targetType = TYPE_UNKNOWN;
+        this.targetType = commons.TYPE_UNKNOWN;
         this.actionType = "textAction";
-        this.direction = DIR_U;
+        this.direction = commons.DIR_U;
         this.distance = 0;
         this.startPos = {
             x: 0,
@@ -137,22 +139,22 @@ class DragClass {
         let sel = ""; //选中的数据,文本，链接
         let text = ""; //选中的文本，跟上面的可能相同可能不同
         switch (this.targetType) {
-            case TYPE_TEXT:
-            case TYPE_TEXT_URL:
+            case commons.TYPE_TEXT:
+            case commons.TYPE_TEXT_URL:
                 text = sel = this.selection;
                 break;
-            case TYPE_TEXT_AREA:
+            case commons.TYPE_TEXT_AREA:
                 sel = this.targetElem.value;
                 text = sel = sel.substring(this.targetElem.selectionStart, this.targetElem.selectionEnd);
                 break;
-            case TYPE_ELEM_A:
+            case commons.TYPE_ELEM_A:
                 sel = this.targetElem.href;
                 text = this.targetElem.textContent;
                 break;
-            case TYPE_ELEM_IMG:
+            case commons.TYPE_ELEM_IMG:
                 sel = this.targetElem.src;
                 break;
-            case TYPE_ELEM:
+            case commons.TYPE_ELEM:
                 sel = "";
                 break;
             default:
@@ -247,25 +249,25 @@ class DragClass {
             return ang1 < ang2 && ang >= ang1 && ang < ang2;
         }
         let d = {
-            normal: DIR_D, //普通的四个方向
-            horizontal: DIR_L, //水平方向,只有左右
-            vertical: DIR_D, //竖直方向，只有上下
-            all: DIR_D //
+            normal: commons.DIR_D, //普通的四个方向
+            horizontal: commons.DIR_L, //水平方向,只有左右
+            vertical: commons.DIR_D, //竖直方向，只有上下
+            all: commons.DIR_D //
         }
 
         let rad = Math.atan2(this.startPos.y - this.endPos.y, this.endPos.x - this.startPos.x);
         let degree = rad * (180 / Math.PI);
         degree = degree >= 0 ? degree : degree + 360; //-180~180转换成0~360
-        if (between(degree, 45, 135)) d.normal = DIR_U;
-        else if (between(degree, 135, 225)) d.normal = DIR_L;
-        else if (between(degree, 225, 315)) d.normal = DIR_D;
-        else d.normal = DIR_R;
+        if (between(degree, 45, 135)) d.normal = commons.DIR_U;
+        else if (between(degree, 135, 225)) d.normal = commons.DIR_L;
+        else if (between(degree, 225, 315)) d.normal = commons.DIR_D;
+        else d.normal = commons.DIR_R;
 
-        if (between(degree, 90, 270)) d.horizontal = DIR_L;
-        else d.horizontal = DIR_R;
+        if (between(degree, 90, 270)) d.horizontal = commons.DIR_L;
+        else d.horizontal = commons.DIR_R;
 
-        if (between(degree, 0, 180)) d.vertical = DIR_U;
-        else d.vertical = DIR_D;
+        if (between(degree, 0, 180)) d.vertical = commons.DIR_U;
+        else d.vertical = commons.DIR_D;
         return d.normal; //暂时
     }
 
@@ -308,21 +310,21 @@ function CSlistener(msg) {
 
     if (elem instanceof HTMLAnchorElement) {
         switch (msg.copy_type) {
-            case COPY_LINK:
+            case commons.COPY_LINK:
                 input.value = elem.href;
                 break;
-            case COPY_TEXT:
+            case commons.COPY_TEXT:
                 input.value = elem.textContent;
                 break;
-            case COPY_IMAGE:
+            case commons.COPY_IMAGE:
                 mydrag.targetElem = elem.querySelector("img");
                 CSlistener(msg); //可能有更好的办法
                 return;
                 //break;
         }
-        // if (msg.copy_type === COPY_LINK) input.value = elem.href;
-        // else if (msg.copy_type === COPY_TEXT) input.value = elem.textContent;
-        // else if (msg.copy_type === COPY_IMAGE) {
+        // if (msg.copy_type === commons.COPY_LINK) input.value = elem.href;
+        // else if (msg.copy_type === commons.COPY_TEXT) input.value = elem.textContent;
+        // else if (msg.copy_type === commons.COPY_IMAGE) {
         //     //如果复制链接里的图像
         //     drag.targetElem = elem.querySelector("img");
         //     listener(msg);
@@ -331,10 +333,10 @@ function CSlistener(msg) {
     else if (elem instanceof HTMLImageElement) {
         if (msg.command === "copy") {
             switch (msg.copy_type) {
-                case COPY_LINK:
+                case commons.COPY_LINK:
                     input.value = elem.src;
                     break;
-                case COPY_IMAGE:
+                case commons.COPY_IMAGE:
                     needExecute = false;
                     getImageBase64(elem.src, (s) => {
                         browser.runtime.sendMessage({ imageBase64: s })
@@ -342,8 +344,8 @@ function CSlistener(msg) {
                     break;
             }
         }
-        // if (msg.copy_type === COPY_LINK) input.value = elem.src;
-        // else if (msg.copy_type === COPY_IMAGE) {
+        // if (msg.copy_type === commons.COPY_LINK) input.value = elem.src;
+        // else if (msg.copy_type === commons.COPY_IMAGE) {
         //     dontExecute = true;
         //     getImageBase64(elem.src, (s) => {
         //         browser.runtime.sendMessage({ imageBase64: s })

--- a/default_config.js
+++ b/default_config.js
@@ -1,4 +1,4 @@
-function _act(act = ACT_NONE, active = BACK_GROUND, pos = TAB_LAST, en = "", search_type = SEARCH_TEXT, copy_type = COPY_LINK) {
+function _act(act = commons.ACT_NONE, active = commons.BACK_GROUND, pos = commons.TAB_LAST, en = "", search_type = commons.SEARCH_TEXT, copy_type = commons.COPY_LINK) {
     return {
         act_name: act,
         tab_active: active,
@@ -35,8 +35,8 @@ var _default_config = {
     },
     Engines: [],
     directionControl: {
-        textAction: ALLOW_ALL,
-        linkAction: ALLOW_ALL,
-        imageAction: ALLOW_ALL
+        textAction: commons.ALLOW_ALL,
+        linkAction: commons.ALLOW_ALL,
+        imageAction: commons.ALLOW_ALL
     },
 }

--- a/options/options.js
+++ b/options/options.js
@@ -1,28 +1,28 @@
 let OptionTextTable = {
-    act: [{ text: "无动作", value: ACT_NONE },
-        { text: "直接打开", value: ACT_OPEN },
-        { text: "搜索", value: ACT_SEARCH },
-        { text: "复制", value: ACT_COPY },
-        { text: "下载", value: ACT_DL },
-        { text: "翻译", value: ACT_TRANS },
-        { text: "二维码", value: ACT_QRCODE },
+    act: [{ text: "无动作", value: commons.ACT_NONE },
+        { text: "直接打开", value: commons.ACT_OPEN },
+        { text: "搜索", value: commons.ACT_SEARCH },
+        { text: "复制", value: commons.ACT_COPY },
+        { text: "下载", value: commons.ACT_DL },
+        { text: "翻译", value: commons.ACT_TRANS },
+        { text: "二维码", value: commons.ACT_QRCODE },
     ],
-    active: [{ text: "前台", value: FORE_GROUND },
-        { text: "后台", value: BACK_GROUND },
+    active: [{ text: "前台", value: commons.FORE_GROUND },
+        { text: "后台", value: commons.BACK_GROUND },
     ],
-    pos: [{ text: "尾", value: TAB_LAST },
-        { text: "首", value: TAB_FIRST },
-        { text: "前", value: TAB_CLEFT },
-        { text: "后", value: TAB_CRIGHT },
+    pos: [{ text: "尾", value: commons.TAB_LAST },
+        { text: "首", value: commons.TAB_FIRST },
+        { text: "前", value: commons.TAB_CLEFT },
+        { text: "后", value: commons.TAB_CRIGHT },
     ],
-    search: [{ text: "链接", value: SEARCH_LINK }, { text: "文本", value: SEARCH_TEXT }, { text: "图像", value: SEARCH_IMAGE }],
-    copy: [{ text: "文本", value: COPY_TEXT }, { text: "链接", value: COPY_LINK }, { text: "图像", value: COPY_IMAGE }]
+    search: [{ text: "链接", value: commons.SEARCH_LINK }, { text: "文本", value: commons.SEARCH_TEXT }, { text: "图像", value: commons.SEARCH_IMAGE }],
+    copy: [{ text: "文本", value: commons.COPY_TEXT }, { text: "链接", value: commons.COPY_LINK }, { text: "图像", value: commons.COPY_IMAGE }]
 }
 let DirTextTable = {
-    DIR_U: { text: "上", value: DIR_U },
-    DIR_D: { text: "下", value: DIR_D },
-    DIR_L: { text: "左", value: DIR_L },
-    DIR_R: { text: "右", value: DIR_R },
+    DIR_U: { text: "上", value: commons.DIR_U },
+    DIR_D: { text: "下", value: commons.DIR_D },
+    DIR_L: { text: "左", value: commons.DIR_L },
+    DIR_R: { text: "右", value: commons.DIR_R },
 }
 let typeNameTable = {
     text: { text: "文本" },
@@ -133,17 +133,17 @@ class DirWrapper {
         })
         //NEW SELECT
         switch (this.act.act_name) {
-            case ACT_COPY:
+            case commons.ACT_COPY:
                 this.copySelect.show();
                 break;
-            case ACT_SEARCH:
+            case commons.ACT_SEARCH:
                 this.activeSelect.show();
                 this.posSelect.show();
                 this.engineSelect.show();
                 this.searchTypeSelect.show();
                 break;
-            case ACT_OPEN:
-            case ACT_QRCODE:
+            case commons.ACT_OPEN:
+            case commons.ACT_QRCODE:
                 this.activeSelect.show();
                 this.posSelect.show();
                 break;
@@ -190,22 +190,22 @@ class Wrapper {
 
         this.child_text = new ChildWrapper(typeNameTable.text.text, conf.textAction, this.callback);
         this.child_text.disableOpt(
-            ACT_DL, ACT_TRANS, ACT_QRCODE,
-            SEARCH_IMAGE, SEARCH_LINK,
-            COPY_LINK, COPY_IMAGE
+            commons.ACT_DL, commons.ACT_TRANS, commons.ACT_QRCODE,
+            commons.SEARCH_IMAGE, commons.SEARCH_LINK,
+            commons.COPY_LINK, commons.COPY_IMAGE
         );
 
         this.child_image = new ChildWrapper(typeNameTable.image.text, conf.imageAction, this.callback);
         this.child_image.disableOpt(
-            ACT_TRANS, ACT_QRCODE,
-            SEARCH_IMAGE, SEARCH_TEXT,
-            COPY_TEXT,
-        )
+            commons.ACT_TRANS, commons.ACT_QRCODE,
+            commons.SEARCH_IMAGE, commons.SEARCH_TEXT,
+            commons.COPY_TEXT
+        );
 
         this.child_link = new ChildWrapper(typeNameTable.link.text, conf.linkAction, this.callback);
         this.child_link.disableOpt(
-            ACT_DL, ACT_TRANS, ACT_QRCODE,
-            SEARCH_IMAGE
+            commons.ACT_DL, commons.ACT_TRANS, commons.ACT_QRCODE,
+            commons.SEARCH_IMAGE
         );
 
         [this.child_text, this.child_link, this.child_image].every(c => this.elem.appendChild(c.elem));
@@ -442,9 +442,9 @@ function messageListener(msg) {
     }
     let elem = mydrag.targetElem;
     let logArea = document.querySelector("#logArea");
-    if (elem instanceof HTMLImageElement && msg.command === "copy" && msg.copy_type === COPY_IMAGE) {
+    if (elem instanceof HTMLImageElement && msg.command === "copy" && msg.copy_type === commons.commons.COPY_IMAGE) {
         log("1.向脚本发送测试信息");
-        browser.runtime.sendNativeMessage(appName, "test").then((r) => {
+        browser.runtime.sendNativeMessage(commons.appName, "test").then((r) => {
             log("2.1.脚本回复：" + r);
         }, (e) => {
             log("2.2.发送测试信息失败:" + e);
@@ -467,7 +467,7 @@ function messageListener(msg) {
             let base64 = canvas.toDataURL("image/png", 1).split(",")[1];
             //发送给background，让background发送字符串到powershell脚本
             log("5.向脚本发送图像")
-            browser.runtime.sendNativeMessage(appName, base64).then((response) => {
+            browser.runtime.sendNativeMessage(commons.appName, base64).then((response) => {
                 log("5.1.发送成功，接收到回复消息:" + response);
             }, (error) => {
                 log("5.2.发送图像失败: " + error);
@@ -487,9 +487,9 @@ function messageListener(msg) {
     // input.style.width = "0px";
     // input.style.height = "0px";
     // if (elem instanceof HTMLAnchorElement) {
-    //     if (msg.copy_type === COPY_LINK) input.value = elem.href;
-    //     else if (msg.copy_type === COPY_TEXT) input.value = elem.textContent;
-    //     else if (msg.copy_type === COPY_IMAGE) {
+    //     if (msg.copy_type === commons.COPY_LINK) input.value = elem.href;
+    //     else if (msg.copy_type === commons.COPY_TEXT) input.value = elem.textContent;
+    //     else if (msg.copy_type === commons.COPY_IMAGE) {
     //         //如果复制的是链接里的图像
     //         drag.targetElem = elem.querySelector("img");
     //         listenerForOptionsPage(msg);
@@ -497,8 +497,8 @@ function messageListener(msg) {
     //     }
     // }
     // else if (elem instanceof HTMLImageElement) {
-    //     if (msg.copy_type === COPY_LINK) input.value = elem.src;
-    //     else if (msg.copy_type === COPY_IMAGE) {
+    //     if (msg.copy_type === commons.COPY_LINK) input.value = elem.src;
+    //     else if (msg.copy_type === commons.COPY_IMAGE) {
     //         log("3.检测到复制图像行为");
     //         dontExecute = true;
     //         //获得图像的扩展
@@ -518,7 +518,7 @@ function messageListener(msg) {
     //             let base64 = canvas.toDataURL("image/png", 1).split(",")[1];
     //             //发送给background，让background发送字符串到powershell脚本
     //             log("5.向脚本发送图像")
-    //             browser.runtime.sendNativeMessage(appName, base64).then((response) => {
+    //             browser.runtime.sendNativeMessage(commons.appName, base64).then((response) => {
     //                 log("5.1.发送成功，接收到回复消息:" + response);
     //             }, (error) => {
     //                 log("5.2.发送图像失败: " + error);

--- a/options/options_debug.js
+++ b/options/options_debug.js
@@ -1,4 +1,4 @@
-if(_DEBUG){
+if(commons._DEBUG){
     document.querySelector("#_debug").style.display = "initial";
 }
 


### PR DESCRIPTION
减少全局变量的暴露，便于管理。
是为了 [Add ESLint & Travis CI](https://github.com/yfdyh000/GlitterDrag/commit/f4b07d03f7e70ffa15f45754f7addf930e11bdf4) 准备的，但如何让ESLint识别全局变量还没弄明白。

功能经测正常，但没有逐一确认。
COPY_LINK: "COPY_LINK", 这些未测能否直接简写为 "COPY_LINK"，用ES6的属性简写。