### PR TITLE
remove getActionName, it is a legacy alias before cleanup

### DIFF
--- a/common.js
+++ b/common.js
@@ -98,7 +98,3 @@ function geti18nMessage(strName) {
     }
     return message;
 }
-
-function getActionName(act){
-    return geti18nMessage(act);
-}

--- a/content_scripts/content_script.js
+++ b/content_scripts/content_script.js
@@ -195,7 +195,7 @@ class DragClass {
             this.direction = this.getDirection();
             if (bgConfig.enablePrompt) {
                 this.promptBox.display();
-                this.promptBox.render(this.direction, getActionName(
+                this.promptBox.render(this.direction, geti18nMessage(
                     bgConfig.Actions[this.actionType][this.direction]["act_name"]
                 ));
             }


### PR DESCRIPTION
#5 的cleanup时合并函数到common.js，但调用忘记改了。不必要的别名。