### PR TITLE
Refine & Add Image reverse search engines

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -336,12 +336,12 @@
         "message": "Chinese",
         "description": "Select box classes on Options - Search Template"
     },
-    "elem_SearchTemplateClasses_Image": {
-        "message": "Image",
+    "elem_SearchTemplateClasses_ImageUrl": {
+        "message": "Image Search(via url)",
         "description": "Select box classes on Options - Search Template"
     },
     "elem_SearchTemplateClasses_ImageSearch": {
-        "message": "Image(upload file)",
+        "message": "Image Search(via upload)",
         "description": "Select box classes on Options - Search Template"
     },
     "elem_Backup": {

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -335,12 +335,12 @@
         "message": "中文",
         "description": "Select box classes on Options - Search Template"
     },
-    "elem_SearchTemplateClasses_Image": {
-        "message": "图片",
+    "elem_SearchTemplateClasses_ImageUrl": {
+        "message": "图片搜索(通过网址)",
         "description": "Select box classes on Options - Search Template"
     },
     "elem_SearchTemplateClasses_ImageSearch": {
-        "message": "图片(上传文件)",
+        "message": "图片搜索(通过上传)",
         "description": "Select box classes on Options - Search Template"
     },
     "elem_Backup": {

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -335,12 +335,12 @@
         "message": "中文",
         "description": "Select box classes on Options - Search Template"
     },
-    "elem_SearchTemplateClasses_Image": {
-        "message": "圖片",
+    "elem_SearchTemplateClasses_ImageUrl": {
+        "message": "圖片搜索(憑藉位址)",
         "description": "Select box classes on Options - Search Template"
     },
     "elem_SearchTemplateClasses_ImageSearch": {
-        "message": "圖片(上傳檔案)",
+        "message": "圖片搜索(憑藉上傳)",
         "description": "Select box classes on Options - Search Template"
     },
     "elem_Backup": {

--- a/options/options.html
+++ b/options/options.html
@@ -93,17 +93,20 @@
                         </select>
                         <select style="display:inline-block">
                             <option selected="selected" disabled="disabled" data-i18n="SearchTemplateClasses_ImageUrl">Image Search(via url)</option>
+                            <option value="https://image.baidu.com/n/pc_search?queryImageUrl=%s">Baidu Image</option>
+                            <option value="https://www.bing.com/images/searchbyimage?FORM=IRSBIQ&cbir=sbi&imgurl=%s">Bing Image</option>
                             <option value="https://www.google.com/searchbyimage?image_url=%s">Google Image</option>
-                            <option value="https://tineye.com/search/?url=%s">Tineye</option>
+                            <option value="https://iqdb.org/?url=%s">IQDB</option>
+                            <option value="https://saucenao.com/search.php?db=999&url=%s">SauceNAO</option>
+                            <option value="https://pic.sogou.com/ris?query=%s&flag=1">Sogou Image</option>
                             <option value="https://www.yandex.com/images/search?url=%s&rpt=imageview">Yandex Image</option>
-                            <option value="http://image.baidu.com/n/pc_search?queryImageUrl=%s">Baidu Image</option>
                         </select>
                         <select style="display:inline-block">
                             <option selected="selected" disabled="disabled" data-i18n="SearchTemplateClasses_ImageSearch">Image Search(via upload)</option>
+                            <option value="{redirect.html}?cmd=search&url={url}&engineName=baidu">Baidu Image</option>
                             <option value="{redirect.html}?cmd=search&url={url}&engineName=google">Google Image</option>
                             <option value="{redirect.html}?cmd=search&url={url}&engineName=tineye">Tineye</option>
                             <option value="{redirect.html}?cmd=search&url={url}&engineName=yandex">Yandex</option>
-                            <option value="{redirect.html}?cmd=search&url={url}&engineName=baidu">Baidu Image</option>
                         </select>
                     </div>
                     <div id="browser-engine" style="display:none">

--- a/options/options.html
+++ b/options/options.html
@@ -92,18 +92,18 @@
                             <option value="https://zh.wikipedia.org/wiki/%s">中文维基百科</option>
                         </select>
                         <select style="display:inline-block">
-                            <option selected="selected" disabled="disabled" data-i18n="SearchTemplateClasses_Image">Image</option>
+                            <option selected="selected" disabled="disabled" data-i18n="SearchTemplateClasses_ImageUrl">Image Search(via url)</option>
                             <option value="https://www.google.com/searchbyimage?image_url=%s">Google Image</option>
                             <option value="https://tineye.com/search/?url=%s">Tineye</option>
                             <option value="https://www.yandex.com/images/search?url=%s&rpt=imageview">Yandex Image</option>
-                            <option value="http://image.baidu.com/n/pc_search?queryImageUrl=%s">百度图片</option>
+                            <option value="http://image.baidu.com/n/pc_search?queryImageUrl=%s">Baidu Image</option>
                         </select>
                         <select style="display:inline-block">
                             <option selected="selected" disabled="disabled" data-i18n="SearchTemplateClasses_ImageSearch">Image Search(via upload)</option>
-                            <option value="{redirect.html}?cmd=search&url={url}&engineName=google">Google Image(upload) </option>
-                            <option value="{redirect.html}?cmd=search&url={url}&engineName=tineye">Tineye(upload)</option> 
-                            <option value="{redirect.html}?cmd=search&url={url}&engineName=yandex">Yandex(upload)</option> 
-                            <option value="{redirect.html}?cmd=search&url={url}&engineName=baidu">百度图片(上传)</option> 
+                            <option value="{redirect.html}?cmd=search&url={url}&engineName=google">Google Image</option>
+                            <option value="{redirect.html}?cmd=search&url={url}&engineName=tineye">Tineye</option>
+                            <option value="{redirect.html}?cmd=search&url={url}&engineName=yandex">Yandex</option>
+                            <option value="{redirect.html}?cmd=search&url={url}&engineName=baidu">Baidu Image</option>
                         </select>
                     </div>
                     <div id="browser-engine" style="display:none">


### PR DESCRIPTION
优化标签。添加4个引擎。按字母顺序排列。

未测试。在`about:debugging#addons`中加载后，拖拽什么（文本/链接/图像，各方向）都没反应（包括扩展旧版本），安装AMO的版本则有反应，不知道为什么。