### PR TITLE
Add: feature{可以指定拖拽链接不同部分作为域名; 可以选择Base64编码/不编码}

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -360,11 +360,43 @@ class ExecutorClass {
                 if (this.action.search_onsite === commons.SEARCH_ONSITE_YES && this.data.actionType !== "imageAction") {
                     url = url.replace("%s", "%x");
                 }
-                return this.openTab(
-                    url
-                        .replace("%s", encodeURIComponent(keyword))
-                        .replace("%x", encodeURIComponent(`site:${this.data.site} ${keyword}`))
-                );
+
+                // 二级域名 (host)
+                let secondaryDomain = '';
+                // 完整域名
+                let domainName = '';
+                // 参数部分
+                let parameter = '';
+                // protocol部分
+                let protocol = '';
+                let tmpIndex = -1;
+                tmpIndex = keyword.indexOf("/");
+                protocol = keyword.substr(0, tmpIndex);
+                domainName = keyword.substr(tmpIndex + 2);
+                tmpIndex = domainName.indexOf("/");
+                parameter = domainName.substr(tmpIndex + 1);
+                domainName = domainName.substr(0, tmpIndex);
+                let domainArr = domainName.split('.');
+                secondaryDomain = domainArr[domainArr.length - 2] + "." + domainArr[domainArr.length - 1]
+
+                // 大写的占位符表示此字段无需Base64编码(一般是非参数)
+                url = url
+                    .replace("%S", keyword)
+                    .replace("%X", `site:${this.data.site} ${keyword}`)
+                    .replace("%O", protocol)
+                    .replace("%D", domainName)
+                    .replace("%H", secondaryDomain)
+                    .replace("%P", parameter)
+
+                url = url
+                    .replace("%s", encodeURIComponent(keyword))
+                    .replace("%x", encodeURIComponent(`site:${this.data.site} ${keyword}`))
+                    .replace("%o", encodeURIComponent(protocol))
+                    .replace("%d", encodeURIComponent(domainName))
+                    .replace("%h", encodeURIComponent(secondaryDomain))
+                    .replace("%p", encodeURIComponent(parameter))
+                
+                return this.openTab(url);
             }
         }
     }

--- a/src/background.js
+++ b/src/background.js
@@ -369,16 +369,22 @@ class ExecutorClass {
                 let parameter = '';
                 // protocol部分
                 let protocol = '';
-                let tmpIndex = -1;
-                tmpIndex = keyword.indexOf("/");
-                protocol = keyword.substr(0, tmpIndex);
-                domainName = keyword.substr(tmpIndex + 2);
-                tmpIndex = domainName.indexOf("/");
-                parameter = domainName.substr(tmpIndex + 1);
-                domainName = domainName.substr(0, tmpIndex);
-                let domainArr = domainName.split('.');
-                secondaryDomain = domainArr[domainArr.length - 2] + "." + domainArr[domainArr.length - 1]
-
+                try {
+                    let urlKeyword = new URL(keyword);
+                    protocol = urlKeyword.protocol;
+                    parameter = urlKeyword.pathname.substr(1) + urlKeyword.search;
+                    domainName = urlKeyword.hostname;
+                    let domainArr = domainName.split('.');
+                    if(domainArr.length < 2) {
+                        // 链接不包含二级域名(例如example.org, 其中example为二级域, org为顶级域) 使用domainName替代
+                        secondaryDomain = domainName;
+                    } else {
+                        secondaryDomain = domainArr[domainArr.length - 2] + "." + domainArr[domainArr.length - 1]
+                    }
+                } catch(Error) {
+                    // 这里的异常用作流程控制: 非链接 -> 不作处理(使用''替换可能存在的误用占位符即可)
+                }
+                
                 // 大写的占位符表示此字段无需Base64编码(一般是非参数)
                 url = url
                     .replace("%S", keyword)


### PR DESCRIPTION
# 新增功能描述
1. 增加新的关键字变量(仅对于链接而言)
    - %o: 链接的protocol部分
    - %d: 链接的域名部分(含子域名)
    - %h: 链接的host部分(指二级域名)
    - %p: 链接的参数部分
2. 允许使用大写的占位符表示无需Base64编码的变量

## 测试链接以及需求描述
see also [issue#113](https://github.com/harytfw/GlitterDrag/issues/113)

# 另:
1. PR的364->380行的那部分内容放置位置可能不符合你的原意
2. 同样是那部分内容 本来是打算判断一下是否是链接的, 但由于1的存在所以就暂时这么写了
3. 感觉还是需要判断一下是否为链接, 但我试过几个正则表达式, 不大理想, 觉得可能你这边有更好的方法